### PR TITLE
Add terminal entity

### DIFF
--- a/Colorblind/Domain/Commands/Parcel/SubmitParcelToTerminal.cs
+++ b/Colorblind/Domain/Commands/Parcel/SubmitParcelToTerminal.cs
@@ -1,1 +1,3 @@
+namespace Domain.Commands.Parcel;
+
 public record SubmitParcelToTerminal(Guid ParcelId, Guid TerminalId);

--- a/Colorblind/Domain/Commands/Parcel/SubmitParcelToTerminal.cs
+++ b/Colorblind/Domain/Commands/Parcel/SubmitParcelToTerminal.cs
@@ -1,3 +1,1 @@
-namespace Domain.Commands.Parcel;
-
-public record SubmitParcelToTerminal(Guid ParcelId, string TerminalId);
+public record SubmitParcelToTerminal(Guid ParcelId, Guid TerminalId);

--- a/Colorblind/Domain/Entities/Parcel.cs
+++ b/Colorblind/Domain/Entities/Parcel.cs
@@ -15,7 +15,7 @@ public record Parcel(Guid Id,
     DeliveryInfo SenderDeliveryInfo,
     DeliveryInfo ReceiverDeliveryInfo,
     ParcelStatus Status = ParcelStatus.Registered,
-    string? TerminalId = null,
+    Guid? TerminalId = null,
     string? CourierId = null
 )
 {

--- a/Colorblind/Domain/Entities/Terminal.cs
+++ b/Colorblind/Domain/Entities/Terminal.cs
@@ -1,0 +1,16 @@
+using Domain.Events.Parcel;
+
+namespace Domain.Entities;
+
+public record Terminal(Guid Id,
+    string Address,
+    List<Guid> ParcelIds)
+{
+    public static Terminal Create(TerminalRegistered create) =>
+        new Terminal(create.TerminalId, create.Address, new List<Guid>());
+
+    public Terminal Apply(ParcelSubmittedToTerminal submittedToTerminal) =>
+        this with { ParcelIds = ParcelIds.Append(submittedToTerminal.ParcelId).ToList() };
+}
+
+public record TerminalRegistered(Guid TerminalId, string Address);

--- a/Colorblind/Domain/Events/Parcel/ParcelSubmittedToTerminal.cs
+++ b/Colorblind/Domain/Events/Parcel/ParcelSubmittedToTerminal.cs
@@ -1,3 +1,3 @@
 namespace Domain.Events.Parcel;
 
-public record ParcelSubmittedToTerminal(Guid ParcelId, string TerminalId);
+public record ParcelSubmittedToTerminal(Guid ParcelId, Guid TerminalId);

--- a/Colorblind/Domain/Rules/TerminalRules.cs
+++ b/Colorblind/Domain/Rules/TerminalRules.cs
@@ -1,0 +1,21 @@
+using Domain.Commands.Parcel;
+using Domain.Entities;
+using Domain.Events.Parcel;
+using Mapster;
+
+namespace Domain.Rules;
+
+public class TerminalRules
+{
+    public static TerminalRegistered Handle(RegisterTerminal command)
+    {
+        return command.Adapt<TerminalRegistered>();
+    }
+
+    public static ParcelSubmittedToTerminal Handle(Terminal terminal, SubmitParcelToTerminal command)
+    {
+        return new ParcelSubmittedToTerminal(command.ParcelId, command.TerminalId);
+    }
+}
+
+public record RegisterTerminal(Guid TerminalId, string Address);

--- a/Colorblind/Persistence/Projections/TerminalProjection.cs
+++ b/Colorblind/Persistence/Projections/TerminalProjection.cs
@@ -1,0 +1,20 @@
+using Domain.Entities;
+using Domain.Events.Parcel;
+using Marten.Events.Projections;
+
+namespace Persistence.Projections;
+
+public class TerminalProjection : MultiStreamAggregation<Terminal, Guid>
+{
+    public TerminalProjection()
+    {
+        Identity<TerminalRegistered>(x => x.TerminalId);
+        Identity<ParcelSubmittedToTerminal>(x => x.TerminalId);
+    }
+
+    public static Terminal Create(TerminalRegistered registered) =>
+        Terminal.Create(registered);
+
+    public static Terminal Handle(Terminal terminal, ParcelSubmittedToTerminal submittedToTerminal) =>
+        terminal.Apply(submittedToTerminal);
+}

--- a/Colorblind/Persistence/SetupMartenExtensions.cs
+++ b/Colorblind/Persistence/SetupMartenExtensions.cs
@@ -1,3 +1,4 @@
+using Domain.Entities;
 using Marten;
 using Marten.Events.Daemon.Resiliency;
 using Marten.Events.Projections;
@@ -24,6 +25,7 @@ public static class SetupMartenExtensions
                         nonPublicMembersStorage: NonPublicMembersStorage.All);
 
                     options.Projections.Add<ParcelProjection>(ProjectionLifecycle.Inline);
+                    options.Projections.Add<TerminalProjection>(ProjectionLifecycle.Inline);
                 }
             ).AddAsyncDaemon(DaemonMode.HotCold);
     }

--- a/Colorblind/WebApp/Controllers/ParcelController.cs
+++ b/Colorblind/WebApp/Controllers/ParcelController.cs
@@ -2,7 +2,6 @@ using Domain.Commands.Parcel;
 using Domain.Entities;
 using Mapster;
 using Marten;
-using Marten.Pagination;
 using Marten.Schema.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Persistence;
@@ -21,14 +20,11 @@ public class ParcelController : ControllerBase
         string code,
         CancellationToken ct)
     {
-        try
-        {
-            return Ok(await querySession.Query<Parcel>().FirstAsync(i => i.Code == code, token: ct));
-        }
-        catch (InvalidOperationException e)
-        {
-            return Problem(statusCode: StatusCodes.Status404NotFound);
-        }
+        var res = await querySession.Query<Parcel>().FirstOrDefaultAsync(i => i.Code == code, token: ct);
+
+        return res is null
+            ? Problem(statusCode: StatusCodes.Status404NotFound, title: $"Parcel with code {code} was not found!")
+            : Ok(res);
     }
 
     [HttpPost("register")]
@@ -46,7 +42,7 @@ public class ParcelController : ControllerBase
 
         await documentSession.Add<Parcel>(parcelId, Handle(command), ct);
 
-        return Created($"parcels/{parcelCode}", new {code = parcelCode});
+        return Created($"parcels/{parcelCode}", new { id = parcelId });
     }
 
     [HttpPost("{code}/unregister")]
@@ -84,7 +80,17 @@ public class ParcelController : ControllerBase
         if (parcel is null)
             return Problem(statusCode: 404, title: $"Parcel with code {code} doesn't exist!");
 
-        var command = new SubmitParcelToTerminal(parcel.Id, terminalId);
+        if (!Guid.TryParse(terminalId, out Guid terminalGuid))
+            return Problem(statusCode: 400, title: "Terminal id is not well-formed!");
+
+        var exists = await documentSession
+            .Query<Terminal>()
+            .AnyAsync(x => x.Id == terminalGuid, token: ct);
+
+        if (!exists)
+            return Problem(statusCode: 404, title: "Terminal not found");
+
+        var command = new SubmitParcelToTerminal(parcel.Id, terminalGuid);
 
         await documentSession.GetAndUpdate<Parcel>(
             parcel.Id,
@@ -143,7 +149,7 @@ public class ParcelController : ControllerBase
         return Ok();
     }
 
-    private Task<Parcel?> GetParcel(IDocumentSession documentSession, string code, CancellationToken ct) =>
+    private Task<Parcel?> GetParcel(IQuerySession documentSession, string code, CancellationToken ct) =>
         documentSession
             .Query<Parcel>()
             .Where(i => i.Code == code)

--- a/Colorblind/WebApp/Controllers/ParcelController.cs
+++ b/Colorblind/WebApp/Controllers/ParcelController.cs
@@ -37,7 +37,9 @@ public class ParcelController : ControllerBase
         var createdDate = DateTime.Now;
         var command = request.Adapt<RegisterParcel>() with
         {
-            Id = parcelId, Code = parcelCode, CreatedDate = createdDate
+            Id = parcelId,
+            Code = parcelCode,
+            CreatedDate = createdDate
         };
 
         await documentSession.Add<Parcel>(parcelId, Handle(command), ct);

--- a/Colorblind/WebApp/Controllers/TerminalController.cs
+++ b/Colorblind/WebApp/Controllers/TerminalController.cs
@@ -1,0 +1,44 @@
+using Domain.Entities;
+using Domain.Rules;
+using Marten;
+using Marten.Schema.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Persistence;
+using static Domain.Rules.TerminalRules;
+
+namespace WebApp.Controllers;
+
+[ApiController]
+[Route("terminals")]
+public class TerminalController : ControllerBase
+{
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Get(IDocumentSession documentSession, string id)
+    {
+        if (!Guid.TryParse(id, out Guid terminalGuid))
+            return Problem(statusCode: 400, title: "Terminal id is not well-formed!");
+
+        var terminal = await documentSession.Query<Terminal>().FirstOrDefaultAsync(x =>
+            x.Id == terminalGuid);
+
+        return terminal is null
+            ? Problem(statusCode: StatusCodes.Status404NotFound, title: "Not found")
+            : Ok(terminal);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Post(IDocumentSession documentSession,
+        RegisterTerminalRequest request,
+        CancellationToken ct)
+    {
+        var id = CombGuidIdGeneration.NewGuid();
+
+        var command = new RegisterTerminal(TerminalId: id, Address: request.Address);
+
+        await documentSession.Add<Terminal>(id, Handle(command), ct: ct);
+
+        return Ok(new { id = id });
+    }
+}
+
+public record RegisterTerminalRequest(string Address);

--- a/client/src/app/components/Header.tsx
+++ b/client/src/app/components/Header.tsx
@@ -1,28 +1,19 @@
-"use client";
-import { useRouter } from "next/navigation";
 import styles from "./Header.module.css";
+import Link from "next/link";
 
 export const Header = () => {
-  const router = useRouter();
-
   return (
     <div className={styles.headerContainer}>
-      <div onClick={() => router.push("")} className={styles.titleContainer}>
+      <Link href="/" className={styles.titleContainer}>
         <h1>FastMail</h1>
-      </div>
+      </Link>
       <div className={styles.buttonContainer}>
-        <button
-          className={styles.headerButton}
-          onClick={() => router.push("/registerparcel/stepone")}
-        >
-          Send Package
-        </button>
-        <button
-          className={styles.headerButton}
-          onClick={() => router.push("/track")}
-        >
-          Track parcel
-        </button>
+        <Link href={"/registerparcel/stepone"}>
+          <button className={styles.headerButton}>Send Package</button>
+        </Link>
+        <a href={"/track"}>
+          <button className={styles.headerButton}>Track parcel</button>
+        </a>
         <button className={styles.headerButton}>F.A.Q.</button>
       </div>
     </div>

--- a/client/src/app/components/Header.tsx
+++ b/client/src/app/components/Header.tsx
@@ -11,9 +11,9 @@ export const Header = () => {
         <Link href={"/registerparcel/stepone"}>
           <button className={styles.headerButton}>Send Package</button>
         </Link>
-        <a href={"/track"}>
+        <Link href={"/track"}>
           <button className={styles.headerButton}>Track parcel</button>
-        </a>
+        </Link>
         <button className={styles.headerButton}>F.A.Q.</button>
       </div>
     </div>

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -1,30 +1,18 @@
-"use client";
-
-import { useRouter } from "next/navigation";
 import styles from "./page.module.css";
+import Link from "next/link";
 
 export default function Home() {
-  const router = useRouter();
-
   return (
     <>
       <div>
         <div>
-          <button
-            className={styles.bigButton}
-            onClick={() => router.push("/registerparcel/stepone")}
-          >
-            Send package
-          </button>
+          <Link href={"/registerparcel/stepone"}>
+            <button className={styles.bigButton}>Send package</button>
+          </Link>
         </div>
-        <div>
-          <button
-            className={styles.bigButton}
-            onClick={() => router.push("/track")}
-          >
-            Track package
-          </button>
-        </div>
+        <Link href={"/track"}>
+          <button className={styles.bigButton}>Track package</button>
+        </Link>
         <div>
           <button className={styles.bigButton}>Help</button>
         </div>

--- a/integrationtesting/tests/test_sample.py
+++ b/integrationtesting/tests/test_sample.py
@@ -37,9 +37,3 @@ def test_register_parcel():
     time.sleep(0.5)
     element = driver.find_element(By.XPATH, "//button[contains(text(), 'Submit')]")
     element.click()
-    time.sleep(2)
-
-    parcel_code = driver.current_url.rsplit('/', 1)[-1]
-
-    response = requests.get(f"{config.server_url}/parcels/{parcel_code}")
-    response.raise_for_status()


### PR DESCRIPTION
I've added a barebones Terminal aggregate. I had to learn how to make a projection consume events from different event streams. Until now, we had a simple ParcelProjection, which generates the projection from one stream. However, with Terminal, we need to listen to Terminal events as well as events coming from multiple Parcels. Namely, the ParcelSubmittedToTerminal event for now. 

RegisterTerminal command was also added, a simple start point for Terminal.

The current desired parcel flow is defined in the test_server.py, now you need an existing terminal to submit a parcel.